### PR TITLE
Use regexp to match exactly the repo name

### DIFF
--- a/lib/specinfra/command/redhat/base/yumrepo.rb
+++ b/lib/specinfra/command/redhat/base/yumrepo.rb
@@ -1,7 +1,7 @@
 class Specinfra::Command::Redhat::Base::Yumrepo < Specinfra::Command::Linux::Base::Yumrepo
   class << self
     def check_exists(repository)
-      "yum repolist all -C | grep ^#{escape(repository)}"
+      "yum repolist all -C | grep -E \"^#{escape(repository)}\(\\s\|$\)\""
     end
 
     def check_is_enabled(repository)


### PR DESCRIPTION
If you have different repos with name like gvp-bi-common, gvp-bi-common-x86_64, gvp-bi-common-noarch, etc...and you want to verify if they exist or not, with the current code it fails even if the repo not exist because it matches only the beginning of the name. Matching the name exactly has the desired behavior.
